### PR TITLE
fixes to reqeust delete, set in_network boolean, filter in_network

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -2,7 +2,7 @@
 
 class ContactsController < ApplicationController
   def index
-    @contacts = Contact.all
+    @contacts = Contact.where(in_network: true)
   end
 
   def show
@@ -52,7 +52,7 @@ class ContactsController < ApplicationController
   private
 
   def contact_params
-    params.require(:contact).permit(:first_name, :last_name, :organization, :title, :link, :bio, :email, :pfp_file)
+    params.require(:contact).permit(:first_name, :last_name, :organization, :title, :link, :bio, :email, :pfp_file, :in_network)
   end
 
   def associate_industries(contact, industries)

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -68,6 +68,11 @@ class RequestsController < ApplicationController
     end
   end
 
+  def delete
+    @request = Request.find(params[:id])
+    @member = Member.find(@request.member_id)
+  end
+
   def approve
     @request = Request.find(params[:id])
     request_type = @request.request_type

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -62,6 +62,11 @@
     <%= form.text_field :industries, :value => industry_list, placeholder: 'Enter tags, separated by commas' %>
     </div>
 
+    <div style="display: none;">
+      <%= form.label :in_network %>
+      <%= form.check_box :in_network, { checked: true }, 'yes', 'no' %>
+    </div>
+
   </div>
     
   <div>

--- a/app/views/requests/delete.html.erb
+++ b/app/views/requests/delete.html.erb
@@ -1,0 +1,22 @@
+
+
+<%= render "events/header"%>
+
+<%= render "events/adminheader"%>
+
+<div style='margin-left: 5%'>
+    <h2>Delete Contact From Network</h2>
+    <%= link_to("Back to Home", requests_path)%>
+    <%= form_for(@request, method: 'delete') do |f| %>
+    
+        <br/>
+        <h3 >Are you sure you want to permanently delete this request?</h3>
+        <% member = @members.find(@request.member_id) %>
+        <strong><p >Request Name: </strong><%= member.full_name %></p>
+    
+        <div >
+            <%= f.submit "Delete Contact" %>
+        </div>
+    
+      <% end %>
+</div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -46,7 +46,7 @@
 
 
           
-          <td><%= link_to("Delete", delete_request_path(request)) %></td>
+          <td><%= button_to "Delete", request, method: :delete %></td>
           
         </tr>
         


### PR DESCRIPTION
Delete button on index page actually works now.
When a user submits the contact form through the website, the contact will appear in the network, otherwise it will not.
Contacts index only shows contacts in the database in which in_network is true. 